### PR TITLE
Switch to oauth token provider when configuring k8s oauth token file to enable picking up refreshed token

### DIFF
--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -46,7 +46,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-            <executable>python</executable>
+            <executable>python3</executable>
               <arguments>
                 <argument>setup.py</argument>
                 <argument>sdist</argument>

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -272,6 +272,8 @@ object LivyConf {
   val KUBERNETES_CLIENT_KEY_FILE = Entry("livy.server.kubernetes.clientKeyFile", "")
   // Kubernetes client cert file path.
   val KUBERNETES_CLIENT_CERT_FILE = Entry("livy.server.kubernetes.clientCertFile", "")
+  // Kubernetes client default namespace.
+  val KUBERNETES_DEFAULT_NAMESPACE = Entry("livy.server.kubernetes.defaultNamespace", "")
 
   // If Livy can't find the Kubernetes app within this time, consider it lost.
   val KUBERNETES_APP_LOOKUP_TIMEOUT = Entry("livy.server.kubernetes.app-lookup-timeout", "600s")

--- a/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
@@ -853,7 +853,7 @@ private[utils] object KubernetesClientFactory {
       .withOption(oauthTokenFile) {
         (file, configBuilder) =>
           configBuilder
-            .withOauthToken(Files.toString(new File(file), Charsets.UTF_8))
+            .withOauthTokenProvider(() => Files.toString(new File(file), Charsets.UTF_8))
       }
       .withOption(caCertFile) {
         (file, configBuilder) => configBuilder.withCaCertFile(file)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Switch to oauth token provider to enable picking up new tokens from updated token file.
Also fix issues related to listing pods under all namespaces and retrieving ingress.
These 2 permissions are not needed in Kumo's setup.
Enable disabling them via config.

## How was this patch tested?

Tested in kumotest Livy server to verify livy sessions can be successfully launched and tokens can be refreshed.
